### PR TITLE
commented out pyrex from requirements/development.txt

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -17,7 +17,7 @@ numpy
 nltk>=2.7.8
 git+https://github.com/dat/pyner.git#egg=ner
 Cython
-Pyrex
+# Pyrex #this is deprecated we should use cython only
 Pillow
 # If you have problems installing wordcloud, please install Cython before
 # running `pip install -r requirements/production.txt`


### PR DESCRIPTION
pyrex project is long dead and has been replaced by cython.
